### PR TITLE
Entries

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,9 +1,10 @@
 class EntriesController < ApplicationController
+  before_action :get_subject
   before_action :set_entry, only: %i[ show edit update destroy ]
 
   # GET /entries or /entries.json
   def index
-    @entries = Entry.all.order(:date)
+    @entries = @subject.entries
   end
 
   # GET /entries/1 or /entries/1.json
@@ -12,7 +13,7 @@ class EntriesController < ApplicationController
 
   # GET /entries/new
   def new
-    @entry = Entry.new
+    @entry = @subject.entries.build
   end
 
   # GET /entries/1/edit
@@ -21,15 +22,15 @@ class EntriesController < ApplicationController
 
   # POST /entries or /entries.json
   def create
-    @entry = Entry.new(entry_params)
+    @entry = @subject.entries.build(entry_params)
 
     respond_to do |format|
       if @entry.save
-        format.html { redirect_to entry_url(@entry), notice: "Entry was successfully created." }
+        format.html { redirect_to subject_entry_path(@subject), notice: "Entry was successfully created." }
         format.json { render :show, status: :created, location: @entry }
       else
         format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @entry.errors, status: :unprocessable_entity }
+        format.json { render json: @subject.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -38,7 +39,7 @@ class EntriesController < ApplicationController
   def update
     respond_to do |format|
       if @entry.update(entry_params)
-        format.html { redirect_to entry_url(@entry), notice: "Entry was successfully updated." }
+        format.html { redirect_to subject_entry_path(@subject), notice: "Entry was successfully updated." }
         format.json { render :show, status: :ok, location: @entry }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -49,24 +50,28 @@ class EntriesController < ApplicationController
 
   # DELETE /entries/1 or /entries/1.json
   def destroy
-    subject_id = @entry.subject_id
+    # subject_id = @entry.subject_id
     @entry.destroy
 
     respond_to do |format|
-      format.html { redirect_to subject_path(subject_id), notice: "Entry was successfully destroyed." }
+      format.html { redirect_to subject_entries_path(@subject), notice: "Entry was successfully destroyed." }
       format.json { head :no_content }
     end
   end
 
   private
 
+  def get_subject
+    @subject = Subject.find(params[:subject_id])
+  end
+
   # Use callbacks to share common setup or constraints between actions.
   def set_entry
-    @entry = Entry.find(params[:id])
+    @entry = @subject.entries.find(params[:id])
   end
 
   # Only allow a list of trusted parameters through.
   def entry_params
-    params.require(:entry).permit(:subject_id, :category_id, :date, :rating, :notes)
+    params.require(:entry).permit(:subject_id, :category_id, :rating, :notes)
   end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -45,7 +45,7 @@ class EntriesController < ApplicationController
   def update
     respond_to do |format|
       if @entry.update(entry_params)
-        format.html { redirect_to subject_entry_path(@subject), notice: "Entry was successfully updated." }
+        format.html { redirect_to (@entry.subject), notice: "Entry was successfully updated." }
         format.json { render :show, status: :ok, location: @entry }
       else
         format.html { render :edit, status: :unprocessable_entity }

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -78,6 +78,6 @@ class EntriesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def entry_params
-    params.require(:entry).permit(:subject_id, :category_id, :rating, :notes)
+    params.require(:entry).permit(:subject_id, :category_id, :date, :rating, :notes)
   end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -24,15 +24,21 @@ class EntriesController < ApplicationController
   def create
     @entry = @subject.entries.build(entry_params)
 
-    respond_to do |format|
-      if @entry.save
-        format.html { redirect_to subject_entry_path(@subject), notice: "Entry was successfully created." }
-        format.json { render :show, status: :created, location: @entry }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @subject.errors, status: :unprocessable_entity }
-      end
+    if @entry.save
+      redirect_to(@entry.subject)
+    else
+      render action: "new"
     end
+
+    # respond_to do |format|
+    #   if @entry.save
+    #     format.html { redirect_to subject_entry_path(@subject), notice: "Entry was successfully created." }
+    #     format.json { render :show, status: :created, location: @entry }
+    #   else
+    #     format.html { render :new, status: :unprocessable_entity }
+    #     format.json { render json: @subject.errors, status: :unprocessable_entity }
+    #   end
+    # end
   end
 
   # PATCH/PUT /entries/1 or /entries/1.json

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -60,7 +60,7 @@ class EntriesController < ApplicationController
     @entry.destroy
 
     respond_to do |format|
-      format.html { redirect_to subject_entries_path(@subject), notice: "Entry was successfully destroyed." }
+      format.html { redirect_to (@entry.subject), notice: "Entry was successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,5 +1,5 @@
 class EntriesController < ApplicationController
-  before_action :get_subject
+  before_action :set_subject
   before_action :set_entry, only: %i[ show edit update destroy ]
 
   # GET /entries or /entries.json
@@ -61,7 +61,7 @@ class EntriesController < ApplicationController
 
   private
 
-  def get_subject
+  def set_subject
     @subject = Subject.find(params[:subject_id])
   end
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,4 +1,4 @@
 class Subject < ApplicationRecord
   belongs_to :category
-  has_many :entries
+  has_many :entries, dependent: :destroy
 end

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -2,11 +2,11 @@
 
 <div class="card" style="col-6">
     <div class="card-body">
-      <h5 class="card-title"><%= entry.date.strftime("%m-%d-%Y") %></h5>
+      <%# <h5 class="card-title"><%= entry.date.strftime("%m-%d-%Y") %></h5>
       <h6 class="card-subtitle mb-2 text-muted">Category: <%= entry.category_id %> | Subject: <%= @subject.name %> </h6>
       <h6 class="card-subtitle mb-2 text-muted">Rating: <%= entry.rating %></h6>
       <p class="card-text"><%= entry.notes %></p>
-      <a href="#" class="card-link"><%= link_to "Show this entry", entry %></a>
+      <%# <a href="#" class="card-link"><%= link_to "Show this entry", entry %></a>
     </div>
   </div>
   

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -2,7 +2,7 @@
 
 <div class="card" style="col-6">
     <div class="card-body">
-      <%# <h5 class="card-title"><%= entry.date.strftime("%m-%d-%Y") %></h5>
+      <h5 class="card-title"><%= entry.date.strftime("%m-%d-%Y") %></h5>
       <h6 class="card-subtitle mb-2 text-muted">Category: <%= entry.category_id %> | Subject: <%= @subject.name %> </h6>
       <h6 class="card-subtitle mb-2 text-muted">Rating: <%= entry.rating %></h6>
       <p class="card-text"><%= entry.notes %></p>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -1,14 +1,12 @@
 <div id="<%= dom_id entry %>" >
-
-<div class="card" style="col-6">
-    <div class="card-body">
-      <h5 class="card-title"><%= entry.date.strftime("%m-%d-%Y") %></h5>
-      <h6 class="card-subtitle mb-2 text-muted">Category: <%= entry.category_id %> | Subject: <%= @subject.name %> </h6>
-      <h6 class="card-subtitle mb-2 text-muted">Rating: <%= entry.rating %></h6>
-      <p class="card-text"><%= entry.notes %></p>
-      <%# <a href="#" class="card-link"><%= link_to "Show this entry", entry %></a>
+  <%= link_to entry.subject do %>
+    <div class="card" style="col-6">
+      <div class="card-body">
+        <h5 class="card-title"><%= entry.date.strftime("%m-%d-%Y") %></h5>
+        <h6 class="card-subtitle mb-2 text-muted">Category: <%= entry.category_id %> | Subject: <%= @subject.name %> </h6>
+        <h6 class="card-subtitle mb-2 text-muted">Rating: <%= entry.rating %></h6>
+        <p class="card-text"><%= entry.notes %></p>
+      </div>
     </div>
-  </div>
-  
-
+  <% end %>
 </div>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -1,3 +1,5 @@
+<%# PAGE NOT ACCESSIBLE %>
+
 <div id="<%= dom_id entry %>" >
   <%= link_to entry.subject do %>
     <div class="card" style="col-6">

--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: entry) do |form| %>
+<%= form_with(model: entry.subject) do |form| %>
   <% if entry.errors.any? %>
     <div style="color: red">
       <h2><%= pluralize(entry.errors.count, "error") %> prohibited this entry from being saved:</h2>

--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -1,47 +1,15 @@
 <%= form_for([@entry.subject, @entry]) do |form| %>
   <% if @entry.errors.any? %>
     <div style="color: red">
-      <h2><%= pluralize(entry.errors.count, "error") %> prohibited this entry from being saved:</h2>
+      <h2><%= pluralize(@entry.errors.count, "error") %> prohibited this entry from being saved:</h2>
 
       <ul>
-        <% entry.errors.each do |error| %>
+        <% @entry.errors.each do |error| %>
           <li><%= error.full_message %></li>
         <% end %>
       </ul>
     </div>
   <% end %>
-
-  <div style="font-family: verdana;">
-    <%# <%= form.label :subject_id, "Subject Name:", style: "display: block"%>
-    <%# <%= form.collection_select :subject_id, Subject.order(:name), :id, :name, include_blank: true, :selected => params[:subject_id] || @entry.id  %>
-  </div>
-
-  <div style="font-family: verdana;">
-    <%# <%= form.label :category_id, "Category Name:", style: "display: block" %>
-    <%# <%= form.collection_select :category_id, Category.order(:name), :id, :name, include_blank: true, :selected => params[:category_id] || @entry.category_id %>
-  </div>
-
-  <div style="font-family: verdana;">
-    <%# <%= form.label :date, style: "display: block" %>
-    <%# <%= form.date_field :date %>
-  </div>
-
-  <div style="font-family: verdana;">
-    <%# <%= form.label :rating, class: "form-label" %>
-    <%# <p>1
-    <%# <%= form.range_field :rating, :class=>"form-range; col-5", :min=> 1, :max=> 5, :id=>"slider1", size: "50em" %>
-    <%# 5</p>
-  </div>
-
-  <div style="font-family: verdana;">
-    <%# <%= form.label :notes, "Review:", style: "display: block" %>
-    <%# <%= form.text_area :notes,  size: "50emx10em" %>
-  </div>
-
-  <div style="font-family: verdana; margin-bottom: 6px">
-    <%# <%= form.submit class:"btn btn-success"%>
-    <%# <%= link_to "Cancel", :back, class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>
-  </div>
 
   <div class="form-group mb-3">
     <%= form.label :subject_id, "Subject Name" %><br />
@@ -53,7 +21,7 @@
   </div>
   <div class="form-group mb-3">
     <%= form.label :date %><br />
-    <%= form.date_field :date, class: "form-control" %>
+    <%= form.date_field :date, required: true, class: "form-control" %>
   </div>
   <div class="form-group mb-3">
     <%= form.label :rating %><br />

--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -63,8 +63,8 @@
     <%= form.label :notes %><br />
     <%= form.text_area :notes, class: "form-control" %>
   </div>
-  <div style="font-family: verdana; margin-bottom: 6px">
+  <div style="font-family: verdana; margin-bottom: 6px", class="actions">
     <%= form.submit class:"btn btn-success"%>
-    <%= link_to "Cancel", :back, class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>
+    <%= link_to "Cancel", subject_path(@subject), class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>
   </div>
 <% end %>

--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -1,5 +1,5 @@
-<%= form_with(model: entry.subject) do |form| %>
-  <% if entry.errors.any? %>
+<%= form_for([@entry.subject, @entry]) do |form| %>
+  <% if @entry.errors.any? %>
     <div style="color: red">
       <h2><%= pluralize(entry.errors.count, "error") %> prohibited this entry from being saved:</h2>
 

--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -53,7 +53,7 @@
   </div>
   <div class="form-group mb-3">
     <%= form.label :date %><br />
-    <%= form.datetime_field :date, class: "form-control" %>
+    <%= form.date_field :date, class: "form-control" %>
   </div>
   <div class="form-group mb-3">
     <%= form.label :rating %><br />

--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -12,31 +12,57 @@
   <% end %>
 
   <div style="font-family: verdana;">
-    <%= form.label :subject_id, "Subject Name:", style: "display: block"%> 
-    <%= form.collection_select :subject_id, Subject.order(:name), :id, :name, include_blank: true, :selected => params[:subject_id] || @entry.subject_id  %>
+    <%# <%= form.label :subject_id, "Subject Name:", style: "display: block"%>
+    <%# <%= form.collection_select :subject_id, Subject.order(:name), :id, :name, include_blank: true, :selected => params[:subject_id] || @entry.id  %>
   </div>
 
   <div style="font-family: verdana;">
-    <%= form.label :category_id, "Category Name:", style: "display: block" %>
-    <%= form.collection_select :category_id, Category.order(:name), :id, :name, include_blank: true, :selected => params[:category_id] || @entry.category_id %>
+    <%# <%= form.label :category_id, "Category Name:", style: "display: block" %>
+    <%# <%= form.collection_select :category_id, Category.order(:name), :id, :name, include_blank: true, :selected => params[:category_id] || @entry.category_id %>
   </div>
 
   <div style="font-family: verdana;">
-    <%= form.label :date, style: "display: block" %>
-    <%= form.date_field :date %>
+    <%# <%= form.label :date, style: "display: block" %>
+    <%# <%= form.date_field :date %>
   </div>
 
   <div style="font-family: verdana;">
-    <%= form.label :rating, class: "form-label" %>
-    <p>1
-    <%= form.range_field :rating, :class=>"form-range; col-5", :min=> 1, :max=> 5, :id=>"slider1", size: "50em" %>5</p>
+    <%# <%= form.label :rating, class: "form-label" %>
+    <%# <p>1
+    <%# <%= form.range_field :rating, :class=>"form-range; col-5", :min=> 1, :max=> 5, :id=>"slider1", size: "50em" %>
+    <%# 5</p>
   </div>
 
   <div style="font-family: verdana;">
-    <%= form.label :notes, "Review:", style: "display: block" %>
-    <%= form.text_area :notes,  size: "50emx10em" %>
+    <%# <%= form.label :notes, "Review:", style: "display: block" %>
+    <%# <%= form.text_area :notes,  size: "50emx10em" %>
   </div>
 
+  <div style="font-family: verdana; margin-bottom: 6px">
+    <%# <%= form.submit class:"btn btn-success"%>
+    <%# <%= link_to "Cancel", :back, class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>
+  </div>
+
+  <div class="form-group mb-3">
+    <%= form.label :subject_id, "Subject Name" %><br />
+    <%= form.text_field :subject_id, class: "form-control" %>
+  </div>
+  <div class="form-group mb-3">
+    <%= form.label :category_id, "Category Name" %><br />
+    <%= form.text_field :category_id, class: "form-control" %>
+  </div>
+  <div class="form-group mb-3">
+    <%= form.label :date %><br />
+    <%= form.datetime_field :date, class: "form-control" %>
+  </div>
+  <div class="form-group mb-3">
+    <%= form.label :rating %><br />
+    <%= form.range_field :rating, in: 1..5, class: "form-control" %>
+  </div>
+  <div class="form-group mb-3">
+    <%= form.label :notes %><br />
+    <%= form.text_area :notes, class: "form-control" %>
+  </div>
   <div style="font-family: verdana; margin-bottom: 6px">
     <%= form.submit class:"btn btn-success"%>
     <%= link_to "Cancel", :back, class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>

--- a/app/views/entries/edit.html.erb
+++ b/app/views/entries/edit.html.erb
@@ -5,6 +5,5 @@
 
     <%= render "form" %>
     
-    <%# <%= link_to "Delete Entry", [entry.subject, @entry], data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}, class:"btn btn-danger" %>
   </div>
 </div>

--- a/app/views/entries/edit.html.erb
+++ b/app/views/entries/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="container-lg">
   <p style="color: green"><%= notice %></p>
   <div class="container-lg">
-    <h1>Editing Entry (put name here) </h1>
+    <h1>Editing Entry (ENTRY NAME) </h1>
 
-    <%= render "form", entry: @entry %>
+    <%= render "form" %>
     
     <%# <%= link_to "Delete Entry", [entry.subject, @entry], data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}, class:"btn btn-danger" %>
   </div>

--- a/app/views/entries/edit.html.erb
+++ b/app/views/entries/edit.html.erb
@@ -1,10 +1,10 @@
 <div class="container-lg">
   <p style="color: green"><%= notice %></p>
   <div class="container-lg">
-    <h1>Editing <%= @entry.date.strftime("%m-%d-%Y") %> </h1>
+    <h1>Editing Entry (put name here) </h1>
 
     <%= render "form", entry: @entry %>
     
-    <%= button_to "Delete Entry", @entry, method: :delete, class:"btn btn-danger", form: {data: {turbo_confirm: "Are you sure?"}, style: 'display:inline-block;'} %>
+    <%# <%= link_to "Delete Entry", [entry.subject, @entry], data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}, class:"btn btn-danger" %>
   </div>
 </div>

--- a/app/views/entries/edit.html.erb
+++ b/app/views/entries/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container-lg">
   <p style="color: green"><%= notice %></p>
   <div class="container-lg">
-    <h1>Editing Entry (ENTRY NAME) </h1>
+    <h1>Editing Entry <%= @entry.date %> </h1>
 
     <%= render "form" %>
     

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -3,6 +3,6 @@
   <div class="container-lg">
     <h1>Create new entry</h1>
 
-    <%= render "form", entry: @entry %>
+    <%= render "form" %>
   </div>
 </div>

--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -1,3 +1,5 @@
+<%# PAGE NOT ACCESSIBLE %>
+
 <div class="container-lg">
   <p style="color: green"><%= notice %></p>
 

--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -2,7 +2,7 @@
   <p style="color: green"><%= notice %></p>
 
   <div class="container-lg" style="margin-bottom: 6px">
-    <h1> Entry: <%= @entry.date.strftime("%m-%d-%Y")%>
+    <h1> Entry: <%= @entry.date %>
     <%= link_to "Edit this entry", edit_subject_entry_path(@entry), class:"btn btn-warning", form: {style: 'display:inline-block;'} %>
     <%= link_to "Back to entry list", subject_path(@entry.subject_id), class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>  
   </div>
@@ -10,7 +10,7 @@
   <div class="container-lg">
     <div class="card" style="col-6">
         <div class="card-body">
-          <h5 class="card-title"><%= @entry.date.strftime("%m-%d-%Y")%>
+          <h5 class="card-title"><%= @entry.date %>
           <h6 class="card-subtitle mb-2 text-muted">Rating: <%= @entry.rating %></h6>
           <!-- <p class="card-text"><%= @entry.category_id %></p> -->
           <p class="card-text"><%= @entry.notes %></p>

--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -2,15 +2,15 @@
   <p style="color: green"><%= notice %></p>
 
   <div class="container-lg" style="margin-bottom: 6px">
-    <h1> Entry: <%= @entry.date.strftime("%m-%d-%Y")%> </h1>
-    <%= link_to "Edit this entry", edit_entry_path(@entry), class:"btn btn-warning", form: {style: 'display:inline-block;'} %>
+    <h1> Entry: <%= @entry.date.strftime("%m-%d-%Y")%>
+    <%= link_to "Edit this entry", edit_subject_entry_path(@entry), class:"btn btn-warning", form: {style: 'display:inline-block;'} %>
     <%= link_to "Back to entry list", subject_path(@entry.subject_id), class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>  
   </div>
 
   <div class="container-lg">
     <div class="card" style="col-6">
         <div class="card-body">
-          <h5 class="card-title"><%= @entry.date.strftime("%m-%d-%Y")%></h5>
+          <h5 class="card-title"><%= @entry.date.strftime("%m-%d-%Y")%>
           <h6 class="card-subtitle mb-2 text-muted">Rating: <%= @entry.rating %></h6>
           <!-- <p class="card-text"><%= @entry.category_id %></p> -->
           <p class="card-text"><%= @entry.notes %></p>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -20,7 +20,7 @@
               <span class="badge rounded-pill text-bg-primary mb-3">You did it!</span>
               <div>
                 <%= link_to 'Edit', edit_subject_entry_url(entry.subject, entry), class: "btn btn-secondary btn-sm" %>
-                <%= link_to 'Destroy', [entry.subject, entry], data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: "btn btn-dark btn-sm" %>
+                <%= link_to 'Destroy', [entry.subject, entry], data: { turbo_method: :delete, turbo_confirm: 'Are you sure you want to delete this entry?' }, class: "btn btn-dark btn-sm" %>
               </div>
             </div>
             <h5 class="card-title mb-2">

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -30,7 +30,7 @@
               </div>
             </div>
             <h5 class="card-title mb-2">
-              <span><%= entry.date.strftime("%m-%d-%Y") %></span>
+              <span><%= entry.date %></span>
             </h5>
             <h6 class="card-subtitle mb-2 text-muted">Category: <%= entry.category_id %> | Subject: <%= @subject.name %> </h6>
             <h6 class="card-subtitle mb-2 text-muted">Rating: <%= entry.rating %></h6>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -7,13 +7,39 @@
     <h3 class="card-subtitle mb-2 text-muted"> <%= @subject.description %> </h3>
     <%# Buttons %>
     <%= link_to "Edit this subject", edit_subject_path(@subject), class:"btn btn-warning", form: {style: 'display:inline-block;'} %>
-    <%# <%= link_to "Add new entry", new_subject_entry_path, class:"btn btn-success", form: {style: 'display:inline-block;'} %>
+    <%= link_to "Add new entry", new_subject_entry_path(@subject), class:"btn btn-success" %>
     <%= link_to "Back to subjects", category_path(@subject.category_id), class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>
   </div>
   
+  <%# <div class="container-lg d-grid gap-2"> %>
+  <%#  <% @subject.entries.each do |entry| %>
+  <%#  <%= render entry %>
+  <%#  <% end %>
+  <%#</div> %>
+
   <div class="container-lg d-grid gap-2">
     <% @subject.entries.each do |entry| %>
-    <%= render entry %>
+      <% if entry.persisted? %>
+         <div class="card mb-3">
+          <div class="card-body">
+            <div class="d-flex justify-content-between">
+              <span class="badge rounded-pill text-bg-primary mb-3">You did it!</span>
+              <div>
+                <%= link_to 'Edit', edit_subject_entry_path(entry.subject, entry), class: "btn btn-secondary btn-sm" %>
+                <%= link_to 'Destroy', [entry.subject, entry], data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: "btn btn-dark btn-sm" %>
+              </div>
+            </div>
+            <h5 class="card-title mb-2">
+              <span><%= entry.date.strftime("%m-%d-%Y") %></span>
+            </h5>
+            <h6 class="card-subtitle mb-2 text-muted">Category: <%= entry.category_id %> | Subject: <%= @subject.name %> </h6>
+            <h6 class="card-subtitle mb-2 text-muted">Rating: <%= entry.rating %></h6>
+            <p><%= entry.notes %></p>
+          </div>
+        </div>
+      <% end %>
+
     <% end %>
   </div>
 </div>
+

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -1,20 +1,21 @@
 <div class="container-lg">
   <p style="color: green"><%= notice %></p>
 
+
+
   <div class="container-lg" style="margin-bottom: 6px">
     <h1> <%= @subject.name%> Entries</h1>
     <%# Description %>
     <h3 class="card-subtitle mb-2 text-muted"> <%= @subject.description %> </h3>
     <%# Buttons %>
     <%= link_to "Edit this subject", edit_subject_path(@subject), class:"btn btn-warning", form: {style: 'display:inline-block;'} %>
-    <%= link_to "Add new entry", new_entry_path(params: {subject_id: @subject.id, category_id: @subject.category_id, subject_name: @subject.name}), class:"btn btn-success", form: {style: 'display:inline-block;'} %>
+    <%# <%= link_to "Add new entry", new_subject_entry_path(params[:subject_id]), class:"btn btn-success", form: {style: 'display:inline-block;'} %>
     <%= link_to "Back to subjects", category_path(@subject.category_id), class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>
   </div>
-
+  
   <div class="container-lg d-grid gap-2">
     <% @subject.entries.each do |entry| %>
     <%= render entry %>
     <% end %>
   </div>
-
 </div>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -25,7 +25,7 @@
             <div class="d-flex justify-content-between">
               <span class="badge rounded-pill text-bg-primary mb-3">You did it!</span>
               <div>
-                <%= link_to 'Edit', edit_subject_entry_path(entry.subject, entry), class: "btn btn-secondary btn-sm" %>
+                <%= link_to 'Edit', edit_subject_entry_url(entry.subject, entry), class: "btn btn-secondary btn-sm" %>
                 <%= link_to 'Destroy', [entry.subject, entry], data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: "btn btn-dark btn-sm" %>
               </div>
             </div>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -1,15 +1,13 @@
 <div class="container-lg">
   <p style="color: green"><%= notice %></p>
 
-
-
   <div class="container-lg" style="margin-bottom: 6px">
     <h1> <%= @subject.name%> Entries</h1>
     <%# Description %>
     <h3 class="card-subtitle mb-2 text-muted"> <%= @subject.description %> </h3>
     <%# Buttons %>
     <%= link_to "Edit this subject", edit_subject_path(@subject), class:"btn btn-warning", form: {style: 'display:inline-block;'} %>
-    <%# <%= link_to "Add new entry", new_subject_entry_path(params[:subject_id]), class:"btn btn-success", form: {style: 'display:inline-block;'} %>
+    <%# <%= link_to "Add new entry", new_subject_entry_path, class:"btn btn-success", form: {style: 'display:inline-block;'} %>
     <%= link_to "Back to subjects", category_path(@subject.category_id), class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>
   </div>
   

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -10,12 +10,6 @@
     <%= link_to "Add new entry", new_subject_entry_path(@subject), class:"btn btn-success" %>
     <%= link_to "Back to subjects", category_path(@subject.category_id), class:"btn btn-secondary", form: {style: 'display:inline-block;'} %>
   </div>
-  
-  <%# <div class="container-lg d-grid gap-2"> %>
-  <%#  <% @subject.entries.each do |entry| %>
-  <%#  <%= render entry %>
-  <%#  <% end %>
-  <%#</div> %>
 
   <div class="container-lg d-grid gap-2">
     <% @subject.entries.each do |entry| %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,1 @@
+Date::DATE_FORMATS[:default] = "%m-%d-%Y"

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,1 @@
-Date::DATE_FORMATS[:default] = "%m-%d-%Y"
+Date::DATE_FORMATS[:default]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root "categories#index"
 
   resources :subjects do
-    resources :entries, except: :index
+    resources :entries
   end
   resources :categories
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   root "categories#index"
 
-  resources :entries, except: :index
-  resources :subjects
+  resources :subjects do
+    resources :entries, except: :index
+  end
   resources :categories
 end

--- a/db/migrate/20230602183814_change_date_to_date_in_entries.rb
+++ b/db/migrate/20230602183814_change_date_to_date_in_entries.rb
@@ -1,0 +1,5 @@
+class ChangeDateToDateInEntries < ActiveRecord::Migration[7.0]
+  def change
+    change_column :entries, :date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_28_185908) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_183814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,7 +24,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_185908) do
   create_table "entries", force: :cascade do |t|
     t.integer "subject_id"
     t.integer "category_id"
-    t.datetime "date"
+    t.date "date"
     t.integer "rating"
     t.text "notes"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,3 +10,9 @@ subject = Subject.create(category_id: 2, average_rating: 3.0, description: "Desc
 subject = Subject.create(category_id: 3, average_rating: 3.0, description: "Description")
 subject = Subject.create(category_id: 4, average_rating: 3.0, description: "Description")
 subject = Subject.create(category_id: 5, average_rating: 3.0, description: "Description")
+
+entry = Entry.create(subject_id: 1, category_id: 1, rating: 1, notes: "Description")
+entry = Entry.create(subject_id: 2, category_id: 2, rating: 2, notes: "Description")
+entry = Entry.create(subject_id: 3, category_id: 3, rating: 3, notes: "Description")
+entry = Entry.create(subject_id: 4, category_id: 4, rating: 4, notes: "Description")
+entry = Entry.create(subject_id: 5, category_id: 5, rating: 5, notes: "Description")


### PR DESCRIPTION
This restructures the relationship between the subject and entry layers.

- Subject show displays all entries
- Edit/Delete buttons are available on entry cards rather than clicking through to entry show
- Rolls back ability to change subject or category assignment when creating/editing entry; need to consider category/subject relationship before rebuilding that functionality
- Requires date to create entry
- Verified user can create, update, delete entry; routing returns user to subject show page